### PR TITLE
Adds timeout to RPC calls

### DIFF
--- a/include/metricq/connection.hpp
+++ b/include/metricq/connection.hpp
@@ -82,6 +82,10 @@ protected:
     void rpc(const std::string& function, ManagementResponseCallback callback,
              json payload = json({}));
     void register_management_callback(const std::string& function, ManagementCallback callback);
+    void register_management_rpc_response_callback(const std::string& correlation_id,
+                                                   ManagementResponseCallback callback);
+
+    std::unique_ptr<AMQP::Envelope> prepare_rpc_envelop(const std::string& function, json payload);
 
     void stop();
     virtual void close();

--- a/include/metricq/connection.hpp
+++ b/include/metricq/connection.hpp
@@ -121,14 +121,14 @@ protected:
                                         RPCResponseCallback callback, Duration timeout);
 
     std::string prepare_message(const std::string& function, json payload);
-    std::unique_ptr<AMQP::Envelope> prepare_rpc_envelop(const std::string& message);
+    std::unique_ptr<AMQP::Envelope> prepare_rpc_envelope(const std::string& message);
 
     void stop();
     virtual void close();
 
     AMQP::Address derive_address(const std::string& address);
 
-    json handle_discover_rpc(const json&);
+    virtual json handle_discover_rpc(const json&);
 
 private:
     void handle_management_message(const AMQP::Message& incoming_message, uint64_t deliveryTag,

--- a/include/metricq/connection.hpp
+++ b/include/metricq/connection.hpp
@@ -127,10 +127,11 @@ protected:
 
     AMQP::Address derive_address(const std::string& address);
 
+    json handle_discover_rpc(const json&);
+
 private:
     void handle_management_message(const AMQP::Message& incoming_message, uint64_t deliveryTag,
                                    bool redelivered);
-    void handle_broadcast_message(const AMQP::Message& message);
 
 protected:
     asio::io_service io_service;
@@ -148,5 +149,7 @@ private:
     std::string management_queue_ = "management";
     std::string management_exchange_ = "metricq.management";
     std::string management_broadcast_exchange_ = "metricq.broadcast";
+
+    metricq::TimePoint starting_time_ = Clock::now();
 };
 } // namespace metricq

--- a/include/metricq/connection.hpp
+++ b/include/metricq/connection.hpp
@@ -114,10 +114,11 @@ protected:
 
     virtual void on_connected() = 0;
 
-    void rpc(const std::string& function, RPCResponseCallback callback, json payload = json({}));
+    void rpc(const std::string& function, RPCResponseCallback callback, json payload = json({}),
+             Duration timeout = std::chrono::seconds(60));
     void register_rpc_callback(const std::string& function, RPCCallback callback);
     void register_rpc_response_callback(const std::string& correlation_id,
-                                        RPCResponseCallback callback);
+                                        RPCResponseCallback callback, Duration timeout);
 
     std::string prepare_message(const std::string& function, json payload);
     std::unique_ptr<AMQP::Envelope> prepare_rpc_envelop(const std::string& message);

--- a/include/metricq/connection.hpp
+++ b/include/metricq/connection.hpp
@@ -30,6 +30,7 @@
 #pragma once
 
 #include <metricq/json.hpp>
+#include <metricq/timer.hpp>
 
 #include <asio/io_service.hpp>
 
@@ -46,14 +47,48 @@ namespace metricq
 
 class BaseConnectionHandler;
 
+class RPCResponseGuard
+{
+public:
+    using Callback = std::function<void(const json& response)>;
+
+    RPCResponseGuard(asio::io_service& io_service, Callback callback,
+                     Duration timeout = std::chrono::seconds(60))
+    : timer_(io_service, std::bind(&RPCResponseGuard::on_timeout, this, std::placeholders::_1)),
+      callback_(std::move(callback))
+    {
+        timer_.start(timeout);
+    }
+
+    ~RPCResponseGuard()
+    {
+        timer_.cancel();
+    }
+
+    Timer::TimerResult on_timeout(std::error_code)
+    {
+        throw std::runtime_error("Timeout during RPC");
+    }
+
+    void operator()(const json& response)
+    {
+        timer_.cancel();
+        callback_(response);
+    }
+
+private:
+    metricq::Timer timer_;
+    Callback callback_;
+};
+
 class Connection
 {
 public:
     void main_loop();
 
 protected:
-    using ManagementCallback = std::function<json(const json& response)>;
-    using ManagementResponseCallback = std::function<void(const json& response)>;
+    using RPCCallback = std::function<json(const json& response)>;
+    using RPCResponseCallback = RPCResponseGuard::Callback;
 
     explicit Connection(const std::string& connection_token, bool add_uuid = false,
                         std::size_t concurrency_hint = 1);
@@ -79,13 +114,13 @@ protected:
 
     virtual void on_connected() = 0;
 
-    void rpc(const std::string& function, ManagementResponseCallback callback,
-             json payload = json({}));
-    void register_management_callback(const std::string& function, ManagementCallback callback);
-    void register_management_rpc_response_callback(const std::string& correlation_id,
-                                                   ManagementResponseCallback callback);
+    void rpc(const std::string& function, RPCResponseCallback callback, json payload = json({}));
+    void register_rpc_callback(const std::string& function, RPCCallback callback);
+    void register_rpc_response_callback(const std::string& correlation_id,
+                                        RPCResponseCallback callback);
 
-    std::unique_ptr<AMQP::Envelope> prepare_rpc_envelop(const std::string& function, json payload);
+    std::string prepare_message(const std::string& function, json payload);
+    std::unique_ptr<AMQP::Envelope> prepare_rpc_envelop(const std::string& message);
 
     void stop();
     virtual void close();
@@ -107,8 +142,8 @@ private:
     // TODO combine & abstract to extra class
     std::unique_ptr<BaseConnectionHandler> management_connection_;
     std::unique_ptr<AMQP::Channel> management_channel_;
-    std::unordered_map<std::string, ManagementCallback> management_callbacks_;
-    std::unordered_map<std::string, ManagementResponseCallback> management_rpc_response_callbacks_;
+    std::unordered_map<std::string, RPCCallback> rpc_callbacks_;
+    std::unordered_map<std::string, RPCResponseGuard> rpc_response_callbacks_;
     std::string management_client_queue_;
     std::string management_queue_ = "management";
     std::string management_exchange_ = "metricq.management";

--- a/include/metricq/data_client.hpp
+++ b/include/metricq/data_client.hpp
@@ -29,9 +29,14 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <metricq/chrono.hpp>
 #include <metricq/connection.hpp>
 
 #include <amqpcpp.h>
+
+#include <memory>
+#include <optional>
+#include <string>
 
 namespace metricq
 {
@@ -52,8 +57,13 @@ protected:
     void close() override;
 
 private:
+    void open_data_connection();
+    json on_discover(const json&);
+
     std::optional<AMQP::Address> data_server_address_;
     std::unique_ptr<BaseConnectionHandler> data_connection_;
+
+    metricq::TimePoint starting_time_ = Clock::now();
 
 protected:
     std::unique_ptr<AMQP::Channel> data_channel_;

--- a/include/metricq/data_client.hpp
+++ b/include/metricq/data_client.hpp
@@ -58,12 +58,9 @@ protected:
 
 private:
     void open_data_connection();
-    json on_discover(const json&);
 
     std::optional<AMQP::Address> data_server_address_;
     std::unique_ptr<BaseConnectionHandler> data_connection_;
-
-    metricq::TimePoint starting_time_ = Clock::now();
 
 protected:
     std::unique_ptr<AMQP::Channel> data_channel_;

--- a/include/metricq/history_client.hpp
+++ b/include/metricq/history_client.hpp
@@ -65,6 +65,7 @@ protected:
 
 private:
     void on_history_response(const AMQP::Message&);
+    json on_discover(const json&);
 
 protected:
     void setup_history_queue(const AMQP::QueueCallback& callback);
@@ -89,5 +90,8 @@ private:
 
 protected:
     std::unique_ptr<AMQP::Channel> history_channel_;
+
+private:
+    metricq::TimePoint starting_time_ = Clock::now();
 };
 } // namespace metricq

--- a/include/metricq/history_client.hpp
+++ b/include/metricq/history_client.hpp
@@ -65,7 +65,6 @@ protected:
 
 private:
     void on_history_response(const AMQP::Message&);
-    json on_discover(const json&);
 
 protected:
     void setup_history_queue(const AMQP::QueueCallback& callback);
@@ -90,8 +89,5 @@ private:
 
 protected:
     std::unique_ptr<AMQP::Channel> history_channel_;
-
-private:
-    metricq::TimePoint starting_time_ = Clock::now();
 };
 } // namespace metricq

--- a/include/metricq/timer.hpp
+++ b/include/metricq/timer.hpp
@@ -29,6 +29,8 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <metricq/chrono.hpp>
+
 #include <asio/basic_waitable_timer.hpp>
 #include <asio/io_service.hpp>
 

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -321,4 +321,16 @@ void Connection::stop()
     close();
     // the io_service will stop itself once all connections are closed
 }
+
+json Connection::handle_discover_rpc(const json&)
+{
+    auto current_time = Clock::now();
+    auto uptime = (current_time - starting_time_).count();
+
+    return { { "alive", true },
+             { "currentTime", Clock::format_iso(current_time) },
+             { "startingTime", Clock::format_iso(starting_time_) },
+             { "uptime", uptime } };
+}
+
 } // namespace metricq

--- a/src/data_client.cpp
+++ b/src/data_client.cpp
@@ -42,7 +42,7 @@ namespace metricq
 {
 DataClient::DataClient(const std::string& token, bool add_uuid) : Connection(token, add_uuid)
 {
-    register_rpc_callback("discover", std::bind(&DataClient::on_discover, this, _1));
+    register_rpc_callback("discover", std::bind(&DataClient::handle_discover_rpc, this, _1));
 }
 
 DataClient::~DataClient() = default;
@@ -110,17 +110,6 @@ void DataClient::close()
 
 void DataClient::on_data_channel_ready()
 {
-}
-
-json DataClient::on_discover(const json&)
-{
-    auto current_time = Clock::now();
-    auto uptime = (current_time - starting_time_).count();
-
-    return { { "alive", true },
-             { "currentTime", Clock::format_iso(current_time) },
-             { "startingTime", Clock::format_iso(starting_time_) },
-             { "uptime", uptime } };
 }
 
 } // namespace metricq

--- a/src/data_client.cpp
+++ b/src/data_client.cpp
@@ -28,26 +28,21 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <metricq/chrono.hpp>
 #include <metricq/data_client.hpp>
 
 #include "connection_handler.hpp"
 #include "log.hpp"
 #include "util.hpp"
 
+#include <functional>
+
+using namespace std::placeholders;
+
 namespace metricq
 {
 DataClient::DataClient(const std::string& token, bool add_uuid) : Connection(token, add_uuid)
 {
-    register_management_callback("discover", [starting_time = Clock::now()](const json&) -> json {
-        auto current_time = Clock::now();
-        auto uptime = (current_time - starting_time).count(); // current uptime in nanoseconds
-
-        return { { "alive", true },
-                 { "currentTime", Clock::format_iso(current_time) },
-                 { "startingTime", Clock::format_iso(starting_time) },
-                 { "uptime", uptime } };
-    });
+    register_rpc_callback("discover", std::bind(&DataClient::on_discover, this, _1));
 }
 
 DataClient::~DataClient() = default;
@@ -71,6 +66,11 @@ void DataClient::data_config(const metricq::json& config)
 
     data_server_address_ = new_data_server_address;
 
+    open_data_connection();
+}
+
+void DataClient::open_data_connection()
+{
     log::debug("opening data connection to {}", *data_server_address_);
     if (data_server_address_->secure())
     {
@@ -111,4 +111,16 @@ void DataClient::close()
 void DataClient::on_data_channel_ready()
 {
 }
+
+json DataClient::on_discover(const json&)
+{
+    auto current_time = Clock::now();
+    auto uptime = (current_time - starting_time_).count();
+
+    return { { "alive", true },
+             { "currentTime", Clock::format_iso(current_time) },
+             { "startingTime", Clock::format_iso(starting_time_) },
+             { "uptime", uptime } };
+}
+
 } // namespace metricq

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -36,7 +36,7 @@ namespace metricq
 {
 Db::Db(const std::string& token) : Sink(token)
 {
-    register_management_callback("config", [this](const json& config) {
+    register_rpc_callback("config", [this](const json& config) {
         auto subscribe_metrics = on_db_config(config);
         this->subscribe(subscribe_metrics);
         return json::object();

--- a/src/history_client.cpp
+++ b/src/history_client.cpp
@@ -44,7 +44,7 @@ namespace metricq
 {
 HistoryClient::HistoryClient(const std::string& token, bool add_uuid) : Connection(token, add_uuid)
 {
-    register_rpc_callback("discover", std::bind(&HistoryClient::on_discover, this, _1));
+    register_rpc_callback("discover", std::bind(&HistoryClient::handle_discover_rpc, this, _1));
 }
 
 HistoryClient::~HistoryClient() = default;
@@ -200,17 +200,6 @@ void HistoryClient::on_history_response(const std::string& id, const HistoryResp
     {
         on_history_response(id, HistoryResponseAggregateView(response));
     }
-}
-
-json HistoryClient::on_discover(const json&)
-{
-    auto current_time = Clock::now();
-    auto uptime = (current_time - starting_time_).count();
-
-    return { { "alive", true },
-             { "currentTime", Clock::format_iso(current_time) },
-             { "startingTime", Clock::format_iso(starting_time_) },
-             { "uptime", uptime } };
 }
 
 } // namespace metricq

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -46,7 +46,7 @@ namespace metricq
 
 Source::Source(const std::string& token) : DataClient(token)
 {
-    register_management_callback("config", [this](const json& config) -> json {
+    register_rpc_callback("config", [this](const json& config) -> json {
         on_source_config(config);
         declare_metrics();
         return json::object();

--- a/src/transformer.cpp
+++ b/src/transformer.cpp
@@ -35,7 +35,7 @@ namespace metricq
 {
 Transformer::Transformer(const std::string& token) : Sink(token)
 {
-    register_management_callback("config", [this](const json& config) -> json {
+    register_rpc_callback("config", [this](const json& config) -> json {
         this->on_transformer_config(config);
         this->subscribe_metrics();
         return metricq::json::object();


### PR DESCRIPTION
This fixes #4 and #5 

It also does some refactoring to the RPC interface. In particular, `Connection::register_management_callback` was renamed to `register_rpc_callback`. I'm not sure, if this function is used outside of the `metricq-cpp` code, so that might break some things.