### PR TITLE
Adds client version and hostname to discover response

### DIFF
--- a/include/metricq/connection.hpp
+++ b/include/metricq/connection.hpp
@@ -128,7 +128,7 @@ protected:
 
     AMQP::Address derive_address(const std::string& address);
 
-    virtual std::string client_version() const;
+    virtual std::string version() const;
     virtual json handle_discover_rpc(const json&);
 
 private:

--- a/include/metricq/connection.hpp
+++ b/include/metricq/connection.hpp
@@ -128,6 +128,7 @@ protected:
 
     AMQP::Address derive_address(const std::string& address);
 
+    virtual std::string client_version() const;
     virtual json handle_discover_rpc(const json&);
 
 private:

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -40,6 +40,8 @@
 #include <metricq/logger.hpp>
 #include <metricq/utils.hpp>
 
+#include <asio/ip/host_name.hpp>
+
 #include <amqpcpp.h>
 
 #include <iostream>
@@ -330,6 +332,11 @@ void Connection::stop()
     // the io_service will stop itself once all connections are closed
 }
 
+std::string Connection::client_version() const
+{
+    return {};
+}
+
 json Connection::handle_discover_rpc(const json&)
 {
     auto current_time = Clock::now();
@@ -337,11 +344,28 @@ json Connection::handle_discover_rpc(const json&)
         std::chrono::duration_cast<std::chrono::duration<double>>(current_time - starting_time_)
             .count();
 
-    return { { "alive", true },
-             { "currentTime", Clock::format_iso(current_time) },
-             { "startingTime", Clock::format_iso(starting_time_) },
-             { "uptime", uptime },
-             { "metricqVersion", metricq::version() } };
+    json response = { { "alive", true },
+                      { "currentTime", Clock::format_iso(current_time) },
+                      { "startingTime", Clock::format_iso(starting_time_) },
+                      { "uptime", uptime },
+                      { "metricqVersion", metricq::version() } };
+
+    if (auto version = client_version(); !version.empty())
+    {
+        response["version"] = version;
+    }
+
+    try
+    {
+        auto hostname = asio::ip::host_name();
+        response["hostname"] = hostname;
+    }
+    catch (asio::system_error& e)
+    {
+        log::error("Couldn't get hostname for system: {}", e.what());
+    }
+
+    return response;
 }
 
 } // namespace metricq

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -332,7 +332,7 @@ void Connection::stop()
     // the io_service will stop itself once all connections are closed
 }
 
-std::string Connection::client_version() const
+std::string Connection::version() const
 {
     return {};
 }
@@ -350,7 +350,7 @@ json Connection::handle_discover_rpc(const json&)
                       { "uptime", uptime },
                       { "metricqVersion", metricq::version() } };
 
-    if (auto version = client_version(); !version.empty())
+    if (auto version = this->version(); !version.empty())
     {
         response["version"] = version;
     }


### PR DESCRIPTION
This fixes #7 and #10.

However, there's no magic CMake voodoo to get the client version. Instead, clients need to override `client_version()` to return a proper value. This ain't p~ony land~ython.