### PR TITLE
Fix transformer reconfigure

### DIFF
--- a/examples/metricq-sink-dummy/src/dummy_sink.cpp
+++ b/examples/metricq-sink-dummy/src/dummy_sink.cpp
@@ -54,7 +54,7 @@ DummySink::DummySink(const std::string& manager_host, const std::string& token,
         }
         Log::info() << "Caught signal " << signal << ". Shutdown.";
         rpc("sink.unsubscribe", [this](const auto&) { (void)this; },
-            { { "dataQueue", data_queue_ }, { "metrics", metrics_ } });
+            { { "dataQueue", data_queue() }, { "metrics", metrics_ } });
         timer_.cancel();
         timeout_timer_.cancel();
     });
@@ -137,7 +137,7 @@ void DummySink::on_data(const AMQP::Message& message, uint64_t delivery_tag, boo
         Log::debug() << "received end message";
         // We used to close the data connection here, but this should not be necessary.
         // It will be closed implicitly from the response callback.
-        rpc("sink.release", [this](const auto&) { close(); }, { { "dataQueue", data_queue_ } });
+        rpc("sink.release", [this](const auto&) { close(); }, { { "dataQueue", data_queue() } });
         return;
     }
 

--- a/examples/metricq-transformer-dummy/src/dummy_transformer.cpp
+++ b/examples/metricq-transformer-dummy/src/dummy_transformer.cpp
@@ -80,7 +80,7 @@ void DummyTransformer::on_transformer_config(const metricq::json& config)
 
         Log::info() << "Transforming " << in_id << " to " << out_id << " with factor " << factor;
 
-        input_metrics.push_back(in_id);
+        input_metrics.emplace(in_id);
         metric_info[in_id] = { out_id, factor };
         (*this)[out_id];
     }

--- a/include/metricq/drain.hpp
+++ b/include/metricq/drain.hpp
@@ -41,7 +41,7 @@ class Drain : public Sink
 public:
     Drain(const std::string& token, const std::string& queue) : Sink(token, true)
     {
-        data_queue_ = queue;
+        data_queue(queue);
     }
     virtual ~Drain() = 0;
 

--- a/include/metricq/sink.hpp
+++ b/include/metricq/sink.hpp
@@ -69,6 +69,13 @@ protected:
 
     void subscribe(const std::vector<std::string>& metrics, int64_t expires = 0);
 
+    void data_queue(const std::string& name);
+
+    const std::string& data_queue() const
+    {
+        return data_queue_;
+    }
+
 private:
     // let's hope the child classes never need to deal with this and the generic callback is
     // sufficient
@@ -76,9 +83,14 @@ private:
     void setup_data_consumer(const std::string& name, int message_count, int consumer_count);
 
 protected:
+    // This is the data_queue that will alter be used for data consumption
     std::string data_queue_;
     // Stored permanently to avoid expensive allocations
     DataChunk data_chunk_;
     std::unordered_map<std::string, Metadata> metadata_;
+
+private:
+    // The data_queue is already setup for the data consumption
+    bool is_data_queue_set_up_ = false;
 };
 } // namespace metricq

--- a/include/metricq/sink.hpp
+++ b/include/metricq/sink.hpp
@@ -85,7 +85,7 @@ private:
     void setup_data_consumer(const std::string& name, int message_count, int consumer_count);
 
 protected:
-    // This is the data_queue that will alter be used for data consumption
+    // This is the data_queue that will be used for data consumption
     std::string data_queue_;
     // Stored permanently to avoid expensive allocations
     DataChunk data_chunk_;

--- a/include/metricq/sink.hpp
+++ b/include/metricq/sink.hpp
@@ -67,6 +67,8 @@ protected:
 
     void sink_config(const json& config);
 
+    void update_metadata(const json& config);
+
     void subscribe(const std::vector<std::string>& metrics, int64_t expires = 0);
 
     void data_queue(const std::string& name);

--- a/include/metricq/transformer.hpp
+++ b/include/metricq/transformer.hpp
@@ -32,8 +32,8 @@
 #include <metricq/metric.hpp>
 #include <metricq/sink.hpp>
 
+#include <set>
 #include <unordered_map>
-#include <vector>
 
 namespace metricq
 {
@@ -73,6 +73,6 @@ private:
     std::unordered_map<std::string, Metric> output_metrics_;
 
 protected:
-    std::vector<std::string> input_metrics;
+    std::set<std::string> input_metrics;
 };
 } // namespace metricq

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -256,7 +256,7 @@ void Connection::handle_management_message(const AMQP::Message& incoming_message
 
     if (auto it = rpc_callbacks_.find(function); it != rpc_callbacks_.end())
     {
-        log::debug("management rpc call received: {}", truncate_string(content_str,100));
+        log::debug("management rpc call received: {}", truncate_string(content_str, 100));
         // incoming message is a RPC-call
 
         try

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -126,13 +126,13 @@ void Db::db_subscribe(const json& metrics)
     // TODO reduce redundancy with Sink::subscribe
     rpc("db.subscribe",
         [this](const json& response) {
-            if (this->data_queue_.empty() || this->history_queue_.empty())
+            if (this->data_queue().empty() || this->history_queue_.empty())
             {
                 // Data queue should really be filled already by the db.register
                 throw std::runtime_error(
                     "data_queue or history_queue empty upon db.subscribe return");
             }
-            if (this->data_queue_ != response.at("dataQueue") ||
+            if (this->data_queue() != response.at("dataQueue") ||
                 this->history_queue_ != response.at("historyQueue"))
             {
                 throw std::runtime_error(

--- a/src/drain.cpp
+++ b/src/drain.cpp
@@ -42,12 +42,12 @@ void Drain::on_connected()
 {
     assert(!metrics_.empty());
     rpc("sink.unsubscribe", [this](const auto& response) { unsubscribe_complete(response); },
-        { { "dataQueue", data_queue_ }, { "metrics", metrics_ } });
+        { { "dataQueue", data_queue() }, { "metrics", metrics_ } });
 }
 
 void Drain::unsubscribe_complete(const json& response)
 {
-    assert(!data_queue_.empty());
+    assert(!data_queue().empty());
 
     sink_config(response);
 }
@@ -60,7 +60,7 @@ void Drain::on_data(const AMQP::Message& message, uint64_t delivery_tag, bool re
         log::debug("received end message");
         // We used to close the data connection here, but this should not be necessary.
         // It will be closed implicitly from the response callback.
-        rpc("sink.release", [this](const auto&) { close(); }, { { "dataQueue", data_queue_ } });
+        rpc("sink.release", [this](const auto&) { close(); }, { { "dataQueue", data_queue() } });
         return;
     }
 

--- a/src/sink.cpp
+++ b/src/sink.cpp
@@ -115,6 +115,25 @@ void Sink::setup_data_consumer(const std::string& name, int message_count, int c
         .onFinalize([]() { log::info("sink data queue consume finalize"); });
 }
 
+void Sink::update_metadata(const json& config)
+{
+    if (config.count("metrics"))
+    {
+        const auto& metrics_metadata = config.at("metrics");
+        for (auto it = metrics_metadata.begin(); it != metrics_metadata.end(); ++it)
+        {
+            if (it.value().is_object())
+            {
+                metadata_.emplace(it.key(), it.value());
+            }
+            else
+            {
+                log::warn("missing metadata for metric {}", it.key());
+            }
+        }
+    }
+}
+
 void Sink::on_data(const AMQP::Message& message, uint64_t delivery_tag, bool redelivered)
 {
     (void)redelivered;

--- a/src/sink.cpp
+++ b/src/sink.cpp
@@ -195,7 +195,8 @@ void Sink::data_queue(const std::string& name)
             "Trying to change data_queue, but data consumption has already started.");
     }
 
-    log::warn("Requested to change data_queue to '{}', but the data_queue '{}' is already set.",
+    log::warn("Requested to change data_queue to '{}', but the data_queue '{}' is already set"
+              " (but not consuming).",
               name, data_queue_);
 
     data_queue_ = name;

--- a/src/sink.cpp
+++ b/src/sink.cpp
@@ -99,7 +99,7 @@ void Sink::setup_data_consumer(const std::string& name, int message_count, int c
     // we do not tolerate other consumers
     if (consumer_count != 0)
     {
-        log::fatal("unexpected consumer count {} - are we not alone in the queue?", consumer_count);
+        log::warn("unexpected consumer count {} - are we not alone in the queue?", consumer_count);
     }
 
     auto message_cb = [this](const AMQP::Message& message, uint64_t delivery_tag,

--- a/src/transformer.cpp
+++ b/src/transformer.cpp
@@ -31,6 +31,8 @@
 #include <metricq/json.hpp>
 #include <metricq/transformer.hpp>
 
+#include <cassert>
+
 namespace metricq
 {
 Transformer::Transformer(const std::string& token) : Sink(token)
@@ -69,10 +71,7 @@ void Transformer::subscribe_metrics()
         [this](const json& response) {
             this->sink_config(response);
 
-            if (this->data_queue() != response.at("dataQueue"))
-            {
-                throw std::runtime_error("inconsistent sink dataQueue setting after subscription");
-            }
+            assert(this->data_queue() == response.at("dataQueue"));
 
             on_transformer_ready();
             declare_metrics();

--- a/src/transformer.cpp
+++ b/src/transformer.cpp
@@ -67,11 +67,9 @@ void Transformer::subscribe_metrics()
     }
     rpc("transformer.subscribe",
         [this](const json& response) {
-            if (this->data_queue_.empty())
-            {
-                this->sink_config(response);
-            }
-            if (this->data_queue_ != response.at("dataQueue"))
+            this->sink_config(response);
+
+            if (this->data_queue() != response.at("dataQueue"))
             {
                 throw std::runtime_error("inconsistent sink dataQueue setting after subscription");
             }


### PR DESCRIPTION
Only the initial sink/transformer subscribe RPC resulted in `sink_config` to be called. Therefore, the internal metadata object might be outdated, then new input_metrics were requested in a reconfigure. To fix that, this PR makes the sink_config method reentry save (in safe cases, otherwise exceptions will be thrown). I've tested it with the combinator and metricq-summary (a drain).