### PR TITLE
feat(timer): Add a skip for the Timer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ set(CORE_SRCS
     src/log.cpp
     src/data_client.cpp
     src/metadata.cpp
+    src/timer.cpp
 )
 
 set(SOURCE_SRCS src/source.cpp)

--- a/include/metricq/timer.hpp
+++ b/include/metricq/timer.hpp
@@ -56,21 +56,7 @@ public:
     {
     }
 
-    void start(Duration interval)
-    {
-        interval_ = std::chrono::duration_cast<std::chrono::microseconds>(interval);
-
-        // As we accept nanosecond resolution durations as interval, but the timer can only support
-        // microseconds, we should check that here
-        if (interval_.count() == 0)
-        {
-            // So the duration got casted to 0us, that means we have a problem
-            throw std::invalid_argument(
-                "metricq::Timer doesn't support sub-microseconds intervals.");
-        }
-
-        restart();
-    }
+    void start(Duration interval);
 
     void start(Callback callback, Duration interval)
     {
@@ -84,17 +70,7 @@ public:
         running_ = false;
     }
 
-    void restart()
-    {
-        if (interval_.count() == 0)
-        {
-            throw std::logic_error("metricq::Timer interval must be set before calling restart!");
-        }
-
-        running_ = true;
-        timer_.expires_after(interval_);
-        timer_.async_wait([this](auto error) { this->timer_callback(error); });
-    }
+    void restart();
 
     bool running() const
     {

--- a/include/metricq/timer.hpp
+++ b/include/metricq/timer.hpp
@@ -115,7 +115,15 @@ private:
 
         if (res == TimerResult::repeat)
         {
-            timer_.expires_at(timer_.expires_at() + interval_);
+            auto deadline = timer_.expires_at() + interval_;
+
+            while (deadline <= std::chrono::system_clock::now())
+            {
+                // TODO think about logging, error reporting, or something
+                deadline += interval_;
+            }
+
+            timer_.expires_at(deadline);
             timer_.async_wait([this](auto error) { this->timer_callback(error); });
         }
         else

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, ZIH,
+// Copyright (c) 2021, ZIH,
 // Technische Universitaet Dresden,
 // Federal Republic of Germany
 //
@@ -27,88 +27,44 @@
 // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#pragma once
 
-#include <metricq/chrono.hpp>
+#include "log.hpp"
 
-#include <asio/basic_waitable_timer.hpp>
-#include <asio/io_service.hpp>
+#include <metricq/logger.hpp>
+#include <metricq/timer.hpp>
 
-#include <functional>
-#include <system_error>
+#include <fmt/chrono.h>
 
 namespace metricq
 {
-
-class Timer
+void Timer::timer_callback(std::error_code err)
 {
-public:
-    enum class TimerResult
+    // Calling start() for an already running or recently canceled timer will cancel all
+    // callbacks on the event loop. So we get the error code operation_aborted here.
+    if (err == asio::error::operation_aborted)
     {
-        repeat,
-        cancel
-    };
-
-    using Callback = std::function<TimerResult(std::error_code)>;
-
-    Timer(asio::io_service& io_service, Callback callback = Callback())
-    : timer_(io_service), callback_(callback), interval_(0)
-    {
+        return;
     }
 
-    void start(Duration interval)
-    {
-        interval_ = std::chrono::duration_cast<std::chrono::microseconds>(interval);
+    auto res = callback_(err);
 
-        // As we accept nanosecond resolution durations as interval, but the timer can only support
-        // microseconds, we should check that here
-        if (interval_.count() == 0)
+    if (res == TimerResult::repeat)
+    {
+        auto deadline = timer_.expires_at() + interval_;
+
+        const auto now = std::chrono::system_clock::now();
+        while (deadline <= now)
         {
-            // So the duration got casted to 0us, that means we have a problem
-            throw std::invalid_argument(
-                "metricq::Timer doesn't support sub-microseconds intervals.");
+            log::warn("Missed deadline {:%FT%T%z}, it is now {:%FT%T%z}", deadline, now);
+            deadline += interval_;
         }
 
-        restart();
-    }
-
-    void start(Callback callback, Duration interval)
-    {
-        callback_ = callback;
-        start(interval);
-    }
-
-    void cancel()
-    {
-        timer_.cancel();
-        running_ = false;
-    }
-
-    void restart()
-    {
-        if (interval_.count() == 0)
-        {
-            throw std::logic_error("metricq::Timer interval must be set before calling restart!");
-        }
-
-        running_ = true;
-        timer_.expires_after(interval_);
+        timer_.expires_at(deadline);
         timer_.async_wait([this](auto error) { this->timer_callback(error); });
     }
-
-    bool running() const
+    else
     {
-        return running_;
+        running_ = false;
     }
-
-private:
-    void timer_callback(std::error_code err);
-
-private:
-    asio::basic_waitable_timer<std::chrono::system_clock> timer_;
-    Callback callback_;
-    std::chrono::microseconds interval_;
-    bool running_ = false;
-};
-
+}
 } // namespace metricq


### PR DESCRIPTION
This makes the metricq::Timer a real deadline timer