### PR TITLE
feat: add a connection name for better identification in the management UI

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -83,12 +83,12 @@ void Connection::connect(const std::string& server_address)
     if (server_address.substr(0, 5) == "amqps")
     {
         management_connection_ =
-            std::make_unique<SSLConnectionHandler>(io_service, "Mgmt connection");
+            std::make_unique<SSLConnectionHandler>(io_service, "Mgmt connection", connection_token_);
     }
     else
     {
         management_connection_ =
-            std::make_unique<PlainConnectionHandler>(io_service, "Mgmt connection");
+            std::make_unique<PlainConnectionHandler>(io_service, "Mgmt connection", connection_token_);
     }
     management_connection_->set_error_callback(
         [this](const auto& message) { this->on_error(message); });

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -82,13 +82,13 @@ void Connection::connect(const std::string& server_address)
 
     if (server_address.substr(0, 5) == "amqps")
     {
-        management_connection_ =
-            std::make_unique<SSLConnectionHandler>(io_service, "Mgmt connection", connection_token_);
+        management_connection_ = std::make_unique<SSLConnectionHandler>(
+            io_service, "Mgmt connection", connection_token_);
     }
     else
     {
-        management_connection_ =
-            std::make_unique<PlainConnectionHandler>(io_service, "Mgmt connection", connection_token_);
+        management_connection_ = std::make_unique<PlainConnectionHandler>(
+            io_service, "Mgmt connection", connection_token_);
     }
     management_connection_->set_error_callback(
         [this](const auto& message) { this->on_error(message); });

--- a/src/connection_handler.cpp
+++ b/src/connection_handler.cpp
@@ -60,7 +60,8 @@ void QueuedBuffer::consume(std::size_t consumed_bytes)
     }
 }
 
-AsioConnectionHandler::AsioConnectionHandler(asio::io_service& io_service, const std::string& name, const std::string& token)
+AsioConnectionHandler::AsioConnectionHandler(asio::io_service& io_service, const std::string& name,
+                                             const std::string& token)
 : heartbeat_timer_(io_service), heartbeat_interval_(std::chrono::seconds(0)), resolver_(io_service),
   name_(name), token_(token)
 {
@@ -73,7 +74,8 @@ PlainConnectionHandler::PlainConnectionHandler(asio::io_service& io_service,
     log::debug("[{}] Using plaintext connection.", name_);
 }
 
-SSLConnectionHandler::SSLConnectionHandler(asio::io_service& io_service, const std::string& name, const std::string& token)
+SSLConnectionHandler::SSLConnectionHandler(asio::io_service& io_service, const std::string& name,
+                                           const std::string& token)
 : AsioConnectionHandler(io_service, name, token), ssl_context_(asio::ssl::context::tls),
   socket_(io_service, ssl_context_)
 {
@@ -200,11 +202,12 @@ void AsioConnectionHandler::onHeartbeat(AMQP::Connection* connection)
     log::trace("[{}] Received heartbeat from server", name_);
 }
 
-void AsioConnectionHandler::onProperties(AMQP::Connection* connection, const AMQP::Table &server, AMQP::Table &client)
+void AsioConnectionHandler::onProperties(AMQP::Connection* connection, const AMQP::Table& server,
+                                         AMQP::Table& client)
 {
     // make sure compilers dont complaint about unused parameters
-    (void) connection;
-    (void) server;
+    (void)connection;
+    (void)server;
 
     client.set("connection_name", name_ + std::string(" ") + token_);
 }

--- a/src/connection_handler.cpp
+++ b/src/connection_handler.cpp
@@ -60,21 +60,21 @@ void QueuedBuffer::consume(std::size_t consumed_bytes)
     }
 }
 
-AsioConnectionHandler::AsioConnectionHandler(asio::io_service& io_service, const std::string& name)
+AsioConnectionHandler::AsioConnectionHandler(asio::io_service& io_service, const std::string& name, const std::string& token)
 : heartbeat_timer_(io_service), heartbeat_interval_(std::chrono::seconds(0)), resolver_(io_service),
-  name_(name)
+  name_(name), token_(token)
 {
 }
 
 PlainConnectionHandler::PlainConnectionHandler(asio::io_service& io_service,
-                                               const std::string& name)
-: AsioConnectionHandler(io_service, name), socket_(io_service)
+                                               const std::string& name, const std::string& token)
+: AsioConnectionHandler(io_service, name, token), socket_(io_service)
 {
     log::debug("[{}] Using plaintext connection.", name_);
 }
 
-SSLConnectionHandler::SSLConnectionHandler(asio::io_service& io_service, const std::string& name)
-: AsioConnectionHandler(io_service, name), ssl_context_(asio::ssl::context::tls),
+SSLConnectionHandler::SSLConnectionHandler(asio::io_service& io_service, const std::string& name, const std::string& token)
+: AsioConnectionHandler(io_service, name, token), ssl_context_(asio::ssl::context::tls),
   socket_(io_service, ssl_context_)
 {
     log::debug("[{}] Using SSL-secured connection.", name_);
@@ -198,6 +198,15 @@ void AsioConnectionHandler::onHeartbeat(AMQP::Connection* connection)
     (void)connection;
 
     log::trace("[{}] Received heartbeat from server", name_);
+}
+
+void AsioConnectionHandler::onProperties(AMQP::Connection* connection, const AMQP::Table &server, AMQP::Table &client)
+{
+    // make sure compilers dont complaint about unused parameters
+    (void) connection;
+    (void) server;
+
+    client.set("connection_name", name_ + std::string(" ") + token_);
 }
 
 /**

--- a/src/connection_handler.hpp
+++ b/src/connection_handler.hpp
@@ -75,7 +75,7 @@ private:
 class AsioConnectionHandler : public AMQP::ConnectionHandler
 {
 public:
-    AsioConnectionHandler(asio::io_service& io_service, const std::string& name);
+    AsioConnectionHandler(asio::io_service& io_service, const std::string& name, const std::string& token);
 
     /**
      *  Beware: when deriving from this class, it might be necessary to
@@ -165,6 +165,14 @@ public:
      */
     virtual void onHeartbeat(AMQP::Connection* connection) override;
 
+
+    /**
+     *  @param  connection      The connection about which information is exchanged
+     *  @param  server          Properties sent by the server
+     *  @param  client          Properties that are to be sent back
+     */
+    virtual void onProperties(AMQP::Connection *connection, const AMQP::Table &server, AMQP::Table &client) override;
+
 public:
     void connect(const AMQP::Address& address);
 
@@ -213,12 +221,13 @@ protected:
     QueuedBuffer send_buffers_;
     bool flush_in_progress_ = false;
     std::string name_;
+    std::string token_;
 };
 
 class PlainConnectionHandler : public AsioConnectionHandler
 {
 public:
-    PlainConnectionHandler(asio::io_service& io_service, const std::string& name);
+    PlainConnectionHandler(asio::io_service& io_service, const std::string& name, const std::string& token);
 
     /**
      *  @see ~AsioConnectionHandler() why this is necessary.
@@ -246,7 +255,7 @@ protected:
 class SSLConnectionHandler : public AsioConnectionHandler
 {
 public:
-    SSLConnectionHandler(asio::io_service& io_service, const std::string& name);
+    SSLConnectionHandler(asio::io_service& io_service, const std::string& name, const std::string& token);
 
     /**
      *  @see ~AsioConnectionHandler() why this is necessary.

--- a/src/connection_handler.hpp
+++ b/src/connection_handler.hpp
@@ -75,7 +75,8 @@ private:
 class AsioConnectionHandler : public AMQP::ConnectionHandler
 {
 public:
-    AsioConnectionHandler(asio::io_service& io_service, const std::string& name, const std::string& token);
+    AsioConnectionHandler(asio::io_service& io_service, const std::string& name,
+                          const std::string& token);
 
     /**
      *  Beware: when deriving from this class, it might be necessary to
@@ -165,13 +166,13 @@ public:
      */
     virtual void onHeartbeat(AMQP::Connection* connection) override;
 
-
     /**
      *  @param  connection      The connection about which information is exchanged
      *  @param  server          Properties sent by the server
      *  @param  client          Properties that are to be sent back
      */
-    virtual void onProperties(AMQP::Connection *connection, const AMQP::Table &server, AMQP::Table &client) override;
+    virtual void onProperties(AMQP::Connection* connection, const AMQP::Table& server,
+                              AMQP::Table& client) override;
 
 public:
     void connect(const AMQP::Address& address);
@@ -227,7 +228,8 @@ protected:
 class PlainConnectionHandler : public AsioConnectionHandler
 {
 public:
-    PlainConnectionHandler(asio::io_service& io_service, const std::string& name, const std::string& token);
+    PlainConnectionHandler(asio::io_service& io_service, const std::string& name,
+                           const std::string& token);
 
     /**
      *  @see ~AsioConnectionHandler() why this is necessary.
@@ -255,7 +257,8 @@ protected:
 class SSLConnectionHandler : public AsioConnectionHandler
 {
 public:
-    SSLConnectionHandler(asio::io_service& io_service, const std::string& name, const std::string& token);
+    SSLConnectionHandler(asio::io_service& io_service, const std::string& name,
+                         const std::string& token);
 
     /**
      *  @see ~AsioConnectionHandler() why this is necessary.

--- a/src/data_client.cpp
+++ b/src/data_client.cpp
@@ -74,11 +74,11 @@ void DataClient::open_data_connection()
     log::debug("opening data connection to {}", redact_address_login(*data_server_address_));
     if (data_server_address_->secure())
     {
-        data_connection_ = std::make_unique<SSLConnectionHandler>(io_service, "Data connection");
+        data_connection_ = std::make_unique<SSLConnectionHandler>(io_service, "Data connection", token());
     }
     else
     {
-        data_connection_ = std::make_unique<PlainConnectionHandler>(io_service, "Data connection");
+        data_connection_ = std::make_unique<PlainConnectionHandler>(io_service, "Data connection", token());
     }
 
     data_connection_->connect(*data_server_address_);

--- a/src/data_client.cpp
+++ b/src/data_client.cpp
@@ -74,11 +74,13 @@ void DataClient::open_data_connection()
     log::debug("opening data connection to {}", redact_address_login(*data_server_address_));
     if (data_server_address_->secure())
     {
-        data_connection_ = std::make_unique<SSLConnectionHandler>(io_service, "Data connection", token());
+        data_connection_ =
+            std::make_unique<SSLConnectionHandler>(io_service, "Data connection", token());
     }
     else
     {
-        data_connection_ = std::make_unique<PlainConnectionHandler>(io_service, "Data connection", token());
+        data_connection_ =
+            std::make_unique<PlainConnectionHandler>(io_service, "Data connection", token());
     }
 
     data_connection_->connect(*data_server_address_);

--- a/src/history_client.cpp
+++ b/src/history_client.cpp
@@ -163,12 +163,12 @@ void HistoryClient::history_config(const json& config)
     log::debug("opening history connection to {}", *data_server_address_);
     if (data_server_address_->secure())
     {
-        history_connection_ = std::make_unique<SSLConnectionHandler>(io_service, "Hist connection");
+        history_connection_ = std::make_unique<SSLConnectionHandler>(io_service, "Hist connection", token());
     }
     else
     {
         history_connection_ =
-            std::make_unique<PlainConnectionHandler>(io_service, "Hist connection");
+            std::make_unique<PlainConnectionHandler>(io_service, "Hist connection", token());
     }
 
     history_connection_->connect(*data_server_address_);

--- a/src/history_client.cpp
+++ b/src/history_client.cpp
@@ -163,7 +163,8 @@ void HistoryClient::history_config(const json& config)
     log::debug("opening history connection to {}", *data_server_address_);
     if (data_server_address_->secure())
     {
-        history_connection_ = std::make_unique<SSLConnectionHandler>(io_service, "Hist connection", token());
+        history_connection_ =
+            std::make_unique<SSLConnectionHandler>(io_service, "Hist connection", token());
     }
     else
     {


### PR DESCRIPTION
Fixes #32 

Possible other solution: don't hand the token down to the `ConnectionHandler` and build the `connection_name` in the calling classes. Downside: the token is in the logs for every `ConnectionHandler` log message